### PR TITLE
Ignore dash, whitespaces

### DIFF
--- a/VoltBot/Services/Implementation/CheckingHistoryService.cs
+++ b/VoltBot/Services/Implementation/CheckingHistoryService.cs
@@ -52,8 +52,8 @@ namespace VoltBot.Services.Implementation
                 if (guildSettings.HistoryStartMessage.Equals(beforeMessage.Content))
                     return;
 
-                string[] beforeParts = beforeMessage.Content.Replace("  ", " ").Split(' ');
-                string[] currentParts = e.Message.Content.Replace("  ", " ").Split(' ');
+                string[] beforeParts = cleanMessage(beforeMessage.Content);
+                string[] currentParts = cleanMessage(e.Message.Content);
 
                 StringBuilder breakingRule = new StringBuilder();
 
@@ -89,6 +89,14 @@ namespace VoltBot.Services.Implementation
                     await discordChannel.SendMessageAsync(discordMessage);
                 }
             }
+        }
+
+        private string[] cleanMessage(string message)
+        {
+            return message.Split(' ')
+                .Select(x => x.Trim())
+                .Where(x => x != "-" && !string.IsNullOrWhiteSpace(x))
+                .ToArray();
         }
     }
 }

--- a/VoltBot/Services/Implementation/CheckingHistoryService.cs
+++ b/VoltBot/Services/Implementation/CheckingHistoryService.cs
@@ -52,8 +52,8 @@ namespace VoltBot.Services.Implementation
                 if (guildSettings.HistoryStartMessage.Equals(beforeMessage.Content))
                     return;
 
-                string[] beforeParts = beforeMessage.Content.Replace("  ", " ").Split(' ');
-                string[] currentParts = e.Message.Content.Replace("  ", " ").Split(' ');
+                string[] beforeParts = cleanMessage(beforeMessage.Content);
+                string[] currentParts = cleanMessage(e.Message.Content);
 
                 StringBuilder breakingRule = new StringBuilder();
 
@@ -89,6 +89,14 @@ namespace VoltBot.Services.Implementation
                     await discordChannel.SendMessageAsync(discordMessage);
                 }
             }
+        }
+
+        private string[] cleanMessage(string message)
+        {
+            return message.Split(' ')
+                .Select(x => x.Trim())
+                .Where(x => x != "-")
+                .ToArray();
         }
     }
 }

--- a/VoltBot/Services/Implementation/CheckingHistoryService.cs
+++ b/VoltBot/Services/Implementation/CheckingHistoryService.cs
@@ -52,8 +52,8 @@ namespace VoltBot.Services.Implementation
                 if (guildSettings.HistoryStartMessage.Equals(beforeMessage.Content))
                     return;
 
-                string[] beforeParts = cleanMessage(beforeMessage.Content);
-                string[] currentParts = cleanMessage(e.Message.Content);
+                string[] beforeParts = CleanMessage(beforeMessage.Content);
+                string[] currentParts = CleanMessage(e.Message.Content);
 
                 StringBuilder breakingRule = new StringBuilder();
 
@@ -91,11 +91,11 @@ namespace VoltBot.Services.Implementation
             }
         }
 
-        private string[] cleanMessage(string message)
+        private string[] CleanMessage(string message)
         {
             return message.Split(' ')
                 .Select(x => x.Trim())
-                .Where(x => x != "-" && !string.IsNullOrWhiteSpace(x))
+                .Where(x => !string.IsNullOrWhiteSpace(x) && "-".Equals(x))
                 .ToArray();
         }
     }


### PR DESCRIPTION
Теперь бот будет игнорировать сообщения, где будет использовать короткое тире. Также бот не будет тригериться большого количества пробелов, т.к. теперь идет фильтрация по пустым вхождениям.

```csharp
return message.Split(' ')
   .Select(x => x.Trim())
   .Where(x => x != "-" && !string.IsNullOrWhiteSpace(x))
   .ToArray();
```

Resolves #32